### PR TITLE
Connecting temperature graph to GreenPiThumb web APIs

### DIFF
--- a/server/dummy_values.py
+++ b/server/dummy_values.py
@@ -29,11 +29,11 @@ def generate_values(value_name, start_value, max_delta):
         A list of random entries. For example, if the value_name was
         "temperature", the list might look like the following:
 
-            [{'timestamp': '20160623T230615.093245Z', 'temperature': 34.2},
-            {'timestamp': '20160623T230640.093245Z', 'temperature': 30.1},
-            {'timestamp': '20160623T230705.093245Z', 'temperature': 29.2},
-            ...
-            {'timestamp': '20160623T230845.093245Z', 'temperature': 28.6}]
+            [{'timestamp': '20160623T230615Z', 'temperature': 34.2},
+             {'timestamp': '20160623T230640Z', 'temperature': 30.1},
+             {'timestamp': '20160623T230705Z', 'temperature': 29.2},
+             ...
+             {'timestamp': '20160623T230845Z', 'temperature': 28.6}]
     """
     values = []
     timestamp = datetime.datetime.now(tz=pytz.utc)
@@ -54,4 +54,4 @@ def _generate_value_entry(value_name, timestamp, value):
 
 
 def _format_timestamp(timestamp):
-    return timestamp.strftime('%Y%m%dT%H:%M:%S.%fZ')
+    return timestamp.strftime('%Y%m%dT%H:%M:%SZ')

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -52,7 +52,7 @@ path {
   <table class="table table-hover">
     <tr>
       <td>Ambient Temperature</td>
-      <td>{{dashboard.temperature | number:1}}&deg; C</td>
+      <td>{{dashboard.latestTemperature | number:1}}&deg; C</td>
     </tr>
     <tr>
       <td>Ambient Humidity</td>
@@ -71,6 +71,6 @@ path {
       <td>{{dashboard.reservoirLevel | number:1}} mL</td>
     </tr>
   </table>
-  <line-graph chart-data="dashboard.myData"></line-graph>
+  <line-graph chart-data="dashboard.temperature"></line-graph>
 </body>
 </html>

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -6,15 +6,13 @@ var dashboardApp = angular.module('dashboardApp', []).
       replace: false,
       scope: {data: '=chartData'},
       link: function (scope, element, attrs) {
-         //TODO(mtlynch): This code probably doesn't belong here.
-
         // Set the dimensions of the canvas / graph
         var margin = {top: 30, right: 20, bottom: 30, left: 50},
           width = 600 - margin.left - margin.right,
           height = 270 - margin.top - margin.bottom;
 
         // Parse the date / time
-        var parseDate = d3.utcParse("%Y%m%dT%H:%M:%S.%LZ");
+        var parseDate = d3.utcParse("%Y%m%dT%H:%M:%SZ");
 
         // Set the ranges
         var x = d3.scaleTime().range([0, width]);
@@ -23,7 +21,6 @@ var dashboardApp = angular.module('dashboardApp', []).
         // Define the axes
         var xAxis = d3.axisBottom(x)
           .ticks(5);
-
         var yAxis = d3.axisLeft(y)
           .ticks(5);
 
@@ -32,46 +29,55 @@ var dashboardApp = angular.module('dashboardApp', []).
           .x(function(d) { return x(d.timestamp); })
           .y(function(d) { return y(d.temperature); });
 
-        // Adds the svg canvas
-        var svg = d3.select("body")
-          .append("svg")
-            .attr("width", width + margin.left + margin.right)
-            .attr("height", height + margin.top + margin.bottom)
-        .append("g")
-            .attr("transform",
-                  "translate(" + margin.left + "," + margin.top + ")");
+        var updateGraph = function(data) {
+          scope.data.forEach(function(d) {
+            d.timestamp = parseDate(d.timestamp);
+            d.temperature = +d.temperature;
+          });
 
-        scope.data.forEach(function(d) {
-          d.timestamp = parseDate(d.timestamp);
-          d.temperature = +d.temperature;
+          // Add the svg canvas
+          var svg = d3.select(element[0])
+            .append("svg")
+              .attr("width", width + margin.left + margin.right)
+              .attr("height", height + margin.top + margin.bottom)
+          .append("g")
+              .attr("transform",
+                    "translate(" + margin.left + "," + margin.top + ")");
+
+          // Scale the range of the data
+          x.domain(d3.extent(data, function(d) { return d.timestamp; }));
+          y.domain([0, d3.max(data, function(d) { return d.temperature; })]);
+
+          // Add the valueline path.
+          svg.append("path")
+            .attr("class", "line")
+            .attr("d", valueline(data));
+
+          // Add the X Axis
+          svg.append("g")
+            .attr("class", "x axis")
+            .attr("transform", "translate(0," + height + ")")
+            .call(xAxis);
+
+          // Add the Y Axis
+          svg.append("g")
+            .attr("class", "y axis")
+            .call(yAxis);
+        };
+        scope.$watch('data', function(newValue) {
+          if (!newValue) {
+            return;
+          }
+          updateGraph(newValue);
         });
-
-        // Scale the range of the data
-        x.domain(d3.extent(scope.data, function(d) { return d.timestamp; }));
-        y.domain([0, d3.max(scope.data, function(d) { return d.temperature; })]);
-
-        // Add the valueline path.
-        svg.append("path")
-          .attr("class", "line")
-          .attr("d", valueline(scope.data));
-
-        // Add the X Axis
-        svg.append("g")
-          .attr("class", "x axis")
-          .attr("transform", "translate(0," + height + ")")
-          .call(xAxis);
-
-        // Add the Y Axis
-        svg.append("g")
-          .attr("class", "y axis")
-          .call(yAxis);
       }
     };
   });
 
 dashboardApp.run(function($http) {
   $http.get('/temperatureHistory.json').success(function(temperatureHistory) {
-    model.temperature = temperatureHistory[temperatureHistory.length - 1].temperature;
+    model.latestTemperature = temperatureHistory[temperatureHistory.length -1].temperature;
+    model.temperature = temperatureHistory;
   });
   $http.get('/ambientHumidityHistory.json').success(function(humidityHistory) {
     model.humidity = humidityHistory[humidityHistory.length - 1].humidity;
@@ -89,12 +95,4 @@ dashboardApp.run(function($http) {
 
 dashboardApp.controller('DashboardCtrl', function ($scope) {
    $scope.dashboard = model;
-   // TODO(mtlynch): Replace synthetic data with data from JSON APIs.
-   $scope.dashboard.myData = [
-     {"timestamp": "20160710T15:03:24.919Z", "temperature": 10},
-     {"timestamp": "20160710T16:03:24.919Z", "temperature": 20},
-     {"timestamp": "20160710T17:03:24.919Z", "temperature": 30},
-     {"timestamp": "20160710T18:03:24.919Z", "temperature": 40},
-     {"timestamp": "20160710T19:03:24.919Z", "temperature": 60},
-   ];
 });


### PR DESCRIPTION
- Gets rid of hardcoded, synthetic data in JS
- Connects the graph to the response from the /temperatureHistory.json API
- Changes the output format of the JSON APIs to exclude fractional seconds
  because JavaScript Dates don't understand microseconds.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeetshetty/greenpithumb_frontend/7)

<!-- Reviewable:end -->
