### PR TITLE
Changing RecordEncoder to generic Encoder

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,5 @@
 coverage
 pyflakes==1.2.3
 pylint==1.5.5
-python-dateutil
 pytz
 yapf==0.14.0

--- a/server/json_encoder.py
+++ b/server/json_encoder.py
@@ -4,12 +4,12 @@ import simplejson
 
 
 def _encode_time(time):
-    """Encodes time in YYYYMMDDTHHMMSS+Z format."""
-    return datetime.datetime.strftime(time, '%Y%m%dT%H%M%S%z')
+    """Encodes time in YYYYMMDDTHHMMSSZ format (assumes UTC time zone)."""
+    return datetime.datetime.strftime(time, '%Y%m%dT%H%M%SZ')
 
 
-class RecordEncoder(simplejson.JSONEncoder):
-    """JSON encoder for GreenPiThumb DB records."""
+class Encoder(simplejson.JSONEncoder):
+    """JSON encoder for GreenPiThumb objects."""
 
     def default(self, obj):
         if isinstance(obj, datetime.datetime):

--- a/server/server.py
+++ b/server/server.py
@@ -7,12 +7,12 @@ import contextlib
 import greenpithumb.greenpithumb.db_store as db_store
 import klein
 
-import record_encoder
+import json_encoder
 
 
 def main(args):
     app = klein.Klein()
-    encoder = record_encoder.RecordEncoder()
+    encoder = json_encoder.Encoder()
     with contextlib.closing(db_store.open_or_create_db(
             args.db_file)) as db_connection:
         temperature_store = db_store.TemperatureStore(db_connection)

--- a/tests/test_json_encoder.py
+++ b/tests/test_json_encoder.py
@@ -2,20 +2,16 @@ import datetime
 import json
 import unittest
 
-from dateutil import tz
 import pytz
 
-from server import record_encoder
+from server import json_encoder
 from server.greenpithumb.greenpithumb import db_store
 
-# Timezone offset info for EST (UTC minus 5 hours).
-UTC_MINUS_5 = tz.tzoffset(None, -18000)
 
-
-class RecordEncoderTest(unittest.TestCase):
+class JSONEncoderTest(unittest.TestCase):
 
     def setUp(self):
-        self.encoder = record_encoder.RecordEncoder()
+        self.encoder = json_encoder.Encoder()
 
     def assertJsonEqual(self, expected, actual):
         json.loads(expected)
@@ -26,7 +22,7 @@ class RecordEncoderTest(unittest.TestCase):
         self.assertJsonEqual(
             """
             {
-              "timestamp": "20170319T150123+0000",
+              "timestamp": "20170319T150123Z",
               "soil_moisture": 305
             }
             """.strip(),
@@ -38,7 +34,7 @@ class RecordEncoderTest(unittest.TestCase):
         self.assertJsonEqual(
             """
             {
-              "timestamp": "20170319T150123+0000",
+              "timestamp": "20170319T150123Z",
               "ambient_light": 87.3
             }
             """.strip(),
@@ -50,7 +46,7 @@ class RecordEncoderTest(unittest.TestCase):
         self.assertJsonEqual(
             """
             {
-              "timestamp": "20170319T150123+0000",
+              "timestamp": "20170319T150123Z",
               "humidity": 21.5
             }
             """.strip(),
@@ -62,7 +58,7 @@ class RecordEncoderTest(unittest.TestCase):
         self.assertJsonEqual(
             """
             {
-              "timestamp": "20170319T150123+0000",
+              "timestamp": "20170319T150123Z",
               "temperature": 21.5
             }
             """.strip(),
@@ -74,7 +70,7 @@ class RecordEncoderTest(unittest.TestCase):
         self.assertJsonEqual(
             """
             {
-              "timestamp": "20170319T150123+0000",
+              "timestamp": "20170319T150123Z",
               "water_pumped": 302.5
             }
             """.strip(),
@@ -83,17 +79,3 @@ class RecordEncoderTest(unittest.TestCase):
                     timestamp=datetime.datetime(
                         2017, 3, 19, 15, 1, 23, 924000, tzinfo=pytz.utc),
                     water_pumped=302.5)))
-
-    def test_encodes_non_utc_records_correctly(self):
-        self.assertJsonEqual(
-            """
-            {
-              "timestamp": "20170319T150123-0500",
-              "temperature": 21.5
-            }
-            """.strip(),
-            self.encoder.encode(
-                db_store.TemperatureRecord(
-                    timestamp=datetime.datetime(
-                        2017, 3, 19, 15, 1, 23, 924000, tzinfo=UTC_MINUS_5),
-                    temperature=21.5)))


### PR DESCRIPTION
RecordEncoder doesn't actually do anything record-specific and we have other
objects (image metadata) that we want to encode with JSON. A normal JSON
encoder can't encode datetimes, but we can just make RecordEncoder a generic
Encoder that encodes datetimes as ISO-8601.

Also makes the small change that timestamps are assumed to be in UTC time
zone, related to the changes in the backend:

* https://github.com/JeetShetty/GreenPiThumb/pull/101
* https://github.com/JeetShetty/GreenPiThumb/pull/109

Changes the serialized format to append a Z (representing UTC time zone) instead
of an offset from UTC in hours.