### PR TITLE
Adding an image indexer

### DIFF
--- a/server/images.py
+++ b/server/images.py
@@ -1,0 +1,59 @@
+import datetime
+import os
+
+import pytz
+
+# Format of GreenPiThumb image files.
+_FILENAME_FORMAT = '%Y-%m-%dT%H%MZ.jpg'
+
+
+def _files_in_directory(directory):
+    paths = os.listdir(directory)
+    return [f for f in paths if os.path.isfile(os.path.join(directory, f))]
+
+
+def _timestamp_from_filename(filename):
+    return datetime.datetime.strptime(filename, _FILENAME_FORMAT).replace(
+        tzinfo=pytz.utc)
+
+
+def _filename_to_index_entry(filename):
+    return {
+        'timestamp': _timestamp_from_filename(filename),
+        'filename': filename,
+    }
+
+
+class Indexer(object):
+    """Creates an index of GreenPiThumb image files."""
+
+    def __init__(self, image_path):
+        """Creates a new Indexer instance
+
+        Args:
+            image_path: Path to the GreenPiThumb images directory.
+        """
+        self._image_path = image_path
+
+    def index(self):
+        """Generates an index of the GreenPiThumb
+
+        Creates an index of all the GreenPiThumb image files in the specified
+        image path. If there are non-image files in the directory, these are
+        ignored. Any GreenPiThumb image files in subdirectories are also
+        ignored.
+
+        Returns:
+            A list of dictionaries, one for each GreenPiThumb image file, where
+            the dictionary has keys 'timestamp' with the datetime when the file
+            was created and 'filename' of the image's filename (without path
+            prefix).
+        """
+        file_index = []
+        for filename in _files_in_directory(self._image_path):
+            try:
+                file_index.append(_filename_to_index_entry(filename))
+            except ValueError:
+                # Ignore filenames that can't be parsed as GrenPiThumb images.
+                pass
+        return file_index

--- a/server/images.py
+++ b/server/images.py
@@ -27,19 +27,19 @@ def _filename_to_index_entry(filename):
 class Indexer(object):
     """Creates an index of GreenPiThumb image files."""
 
-    def __init__(self, image_path):
-        """Creates a new Indexer instance
+    def __init__(self, images_path):
+        """Creates a new Indexer instance.
 
         Args:
-            image_path: Path to the GreenPiThumb images directory.
+            images_path: Path to the GreenPiThumb images directory.
         """
-        self._image_path = image_path
+        self._images_path = images_path
 
     def index(self):
-        """Generates an index of the GreenPiThumb
+        """Generates an index of the GreenPiThumb image files.
 
         Creates an index of all the GreenPiThumb image files in the specified
-        image path. If there are non-image files in the directory, these are
+        images path. If there are non-image files in the directory, these are
         ignored. Any GreenPiThumb image files in subdirectories are also
         ignored.
 
@@ -50,10 +50,10 @@ class Indexer(object):
             prefix).
         """
         file_index = []
-        for filename in _files_in_directory(self._image_path):
+        for filename in _files_in_directory(self._images_path):
             try:
                 file_index.append(_filename_to_index_entry(filename))
             except ValueError:
-                # Ignore filenames that can't be parsed as GrenPiThumb images.
+                # Ignore filenames that can't be parsed as GreenPiThumb images.
                 pass
         return file_index

--- a/server/server.py
+++ b/server/server.py
@@ -7,12 +7,14 @@ import contextlib
 import greenpithumb.greenpithumb.db_store as db_store
 import klein
 
+import images
 import json_encoder
 
 
 def main(args):
     app = klein.Klein()
     encoder = json_encoder.Encoder()
+    image_indexer = images.Indexer(args.image_path)
     with contextlib.closing(db_store.open_or_create_db(
             args.db_file)) as db_connection:
         temperature_store = db_store.TemperatureStore(db_connection)
@@ -36,6 +38,10 @@ def main(args):
         def ambient_humidity_history(request):
             return encoder.encode(humidity_store.get())
 
+        @app.route('/images.json')
+        def image_index(request):
+            return encoder.encode(image_indexer.index())
+
         app.run('0.0.0.0', args.port)
 
 
@@ -48,5 +54,11 @@ if __name__ == '__main__':
         '-d',
         '--db_file',
         help='Path to GreenPiThumb database file',
+        required=True)
+    parser.add_argument(
+        '-i',
+        '--image_path',
+        type=str,
+        help='Path to folder containing GreenPiThumb images',
         required=True)
     main(parser.parse_args())

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,87 @@
+import datetime
+import os
+import shutil
+import tempfile
+import unittest
+
+import pytz
+
+from server import images
+
+
+class ImagesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.indexer = images.Indexer(self.temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_indexes_image_files(self):
+        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
+        open(os.path.join(self.temp_dir, '2017-04-01T1853Z.jpg'), 'a').close()
+        open(os.path.join(self.temp_dir, '2017-04-02T0000Z.jpg'), 'a').close()
+        self.assertItemsEqual(
+            [
+                {
+                    'timestamp': datetime.datetime(
+                        2017, 4, 1, 18, 51, 0, tzinfo=pytz.utc),
+                    'filename': '2017-04-01T1851Z.jpg',
+                },
+                {
+                    'timestamp': datetime.datetime(
+                        2017, 4, 1, 18, 53, 0, tzinfo=pytz.utc),
+                    'filename': '2017-04-01T1853Z.jpg',
+                },
+                {
+                    'timestamp': datetime.datetime(
+                        2017, 4, 2, 0, 0, 0, tzinfo=pytz.utc),
+                    'filename': '2017-04-02T0000Z.jpg',
+                },
+            ],
+            self.indexer.index())
+
+    def test_excludes_non_greenpithumb_image_files(self):
+        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
+        open(os.path.join(self.temp_dir, '2017-04-01T1853Z.txt'), 'a').close()
+        open(os.path.join(self.temp_dir, 'dummyfile.jpg'), 'a').close()
+        open(
+            os.path.join(self.temp_dir, '2017-04-01T1845Z-extrajunk.jpg'),
+            'a').close()
+        self.assertItemsEqual(
+            [{
+                'timestamp': datetime.datetime(
+                    2017, 4, 1, 18, 51, 0, tzinfo=pytz.utc),
+                'filename': '2017-04-01T1851Z.jpg',
+            },],
+            self.indexer.index())
+
+    def test_excludes_directories(self):
+        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
+        os.mkdir(os.path.join(self.temp_dir, 'dummydir'))
+        # Make a directory named like an image file.
+        os.makedirs(os.path.join(self.temp_dir, '2017-04-05T0000Z.jpg'))
+
+        self.assertItemsEqual(
+            [{
+                'timestamp': datetime.datetime(
+                    2017, 4, 1, 18, 51, 0, tzinfo=pytz.utc),
+                'filename': '2017-04-01T1851Z.jpg',
+            },],
+            self.indexer.index())
+
+    def test_excludes_subdirectories(self):
+        subdirectory_path = os.path.join(self.temp_dir, 'child_dir')
+        os.mkdir(subdirectory_path)
+        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
+        open(os.path.join(subdirectory_path, '2017-05-08T0000Z.jpg'),
+             'a').close()
+
+        self.assertItemsEqual(
+            [{
+                'timestamp': datetime.datetime(
+                    2017, 4, 1, 18, 51, 0, tzinfo=pytz.utc),
+                'filename': '2017-04-01T1851Z.jpg',
+            },],
+            self.indexer.index())

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -61,7 +61,7 @@ class ImagesTest(unittest.TestCase):
         open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
         os.mkdir(os.path.join(self.temp_dir, 'dummydir'))
         # Make a directory named like an image file.
-        os.makedirs(os.path.join(self.temp_dir, '2017-04-05T0000Z.jpg'))
+        os.mkdir(os.path.join(self.temp_dir, '2017-04-05T0000Z.jpg'))
 
         self.assertItemsEqual(
             [{

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -9,6 +9,11 @@ import pytz
 from server import images
 
 
+def createEmptyFile(filepath):
+    """Creates an empty file at the given path and closes the file handle."""
+    open(filepath, 'a').close()
+
+
 class ImagesTest(unittest.TestCase):
 
     def setUp(self):
@@ -19,9 +24,9 @@ class ImagesTest(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_indexes_image_files(self):
-        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
-        open(os.path.join(self.temp_dir, '2017-04-01T1853Z.jpg'), 'a').close()
-        open(os.path.join(self.temp_dir, '2017-04-02T0000Z.jpg'), 'a').close()
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'))
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-01T1853Z.jpg'))
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-02T0000Z.jpg'))
         self.assertItemsEqual(
             [
                 {
@@ -43,12 +48,11 @@ class ImagesTest(unittest.TestCase):
             self.indexer.index())
 
     def test_excludes_non_greenpithumb_image_files(self):
-        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
-        open(os.path.join(self.temp_dir, '2017-04-01T1853Z.txt'), 'a').close()
-        open(os.path.join(self.temp_dir, 'dummyfile.jpg'), 'a').close()
-        open(
-            os.path.join(self.temp_dir, '2017-04-01T1845Z-extrajunk.jpg'),
-            'a').close()
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'))
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-01T1853Z.txt'))
+        createEmptyFile(os.path.join(self.temp_dir, 'dummyfile.jpg'))
+        createEmptyFile(
+            os.path.join(self.temp_dir, '2017-04-01T1845Z-extrajunk.jpg'))
         self.assertItemsEqual(
             [{
                 'timestamp': datetime.datetime(
@@ -58,7 +62,7 @@ class ImagesTest(unittest.TestCase):
             self.indexer.index())
 
     def test_excludes_directories(self):
-        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'))
         os.mkdir(os.path.join(self.temp_dir, 'dummydir'))
         # Make a directory named like an image file.
         os.mkdir(os.path.join(self.temp_dir, '2017-04-05T0000Z.jpg'))
@@ -74,9 +78,8 @@ class ImagesTest(unittest.TestCase):
     def test_excludes_subdirectories(self):
         subdirectory_path = os.path.join(self.temp_dir, 'child_dir')
         os.mkdir(subdirectory_path)
-        open(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'), 'a').close()
-        open(os.path.join(subdirectory_path, '2017-05-08T0000Z.jpg'),
-             'a').close()
+        createEmptyFile(os.path.join(self.temp_dir, '2017-04-01T1851Z.jpg'))
+        createEmptyFile(os.path.join(subdirectory_path, '2017-05-08T0000Z.jpg'))
 
         self.assertItemsEqual(
             [{


### PR DESCRIPTION
The backend is going to be placing images in the frontend's static files
location, but the client-side JavaScript needs a way of knowing what files
are there. The images indexer (and API) give the client-side JavaScript an
index of these files.