### PR TITLE
Adding unit test support for HTTP handler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-klein
+flask
 simplejson

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,46 @@
+import flask
+
+import json_encoder
+
+
+def create(image_indexer, temperature_store, light_store, soil_moisture_store,
+           humidity_store):
+    """Creates a new GreenPiThumb flask app.
+
+    Creates a GreenPiThumb app capable of servicing requests to the GreenPiThumb
+    frontend's dynamic resources.
+
+    Args:
+        image_indexer: Interface for indexing GreenPiThumb images.
+        temperature_store: Interface for retrieving temperature records.
+        light_store: Interface for retrieving light records.
+        soil_moisture_store: Interface for retrieving soil moisture records.
+        humidity_store: Interface for retrieving humidity records.
+
+    Returns:
+        A Flask app that can serve HTTP requests.
+    """
+    app = flask.Flask(__name__)
+    encoder = json_encoder.Encoder()
+
+    @app.route('/temperatureHistory.json')
+    def temperature_history():
+        return encoder.encode(temperature_store.get())
+
+    @app.route('/lightHistory.json')
+    def light_history():
+        return encoder.encode(light_store.get())
+
+    @app.route('/soilMoistureHistory.json')
+    def soil_moisture_history():
+        return encoder.encode(soil_moisture_store.get())
+
+    @app.route('/humidityHistory.json')
+    def humidity_history():
+        return encoder.encode(humidity_store.get())
+
+    @app.route('/images.json')
+    def image_index():
+        return encoder.encode(image_indexer.index())
+
+    return app

--- a/server/server.py
+++ b/server/server.py
@@ -5,16 +5,12 @@ import argparse
 import contextlib
 
 import greenpithumb.greenpithumb.db_store as db_store
-import klein
 
+import app
 import images
-import json_encoder
 
 
 def main(args):
-    app = klein.Klein()
-    encoder = json_encoder.Encoder()
-    image_indexer = images.Indexer(args.image_path)
     with contextlib.closing(db_store.open_or_create_db(
             args.db_file)) as db_connection:
         temperature_store = db_store.TemperatureStore(db_connection)
@@ -22,27 +18,9 @@ def main(args):
         soil_moisture_store = db_store.SoilMoistureStore(db_connection)
         humidity_store = db_store.HumidityStore(db_connection)
 
-        @app.route('/temperatureHistory.json')
-        def temperature_history(request):
-            return encoder.encode(temperature_store.get())
-
-        @app.route('/lightHistory.json')
-        def light_history(request):
-            return encoder.encode(light_store.get())
-
-        @app.route('/soilMoistureHistory.json')
-        def soil_moisture_history(request):
-            return encoder.encode(soil_moisture_store.get())
-
-        @app.route('/humidityHistory.json')
-        def humidity_history(request):
-            return encoder.encode(humidity_store.get())
-
-        @app.route('/images.json')
-        def image_index(request):
-            return encoder.encode(image_indexer.index())
-
-        app.run('0.0.0.0', args.port)
+        app.create(
+            images.Indexer(args.image_path), temperature_store, light_store,
+            soil_moisture_store, humidity_store).run('0.0.0.0', args.port)
 
 
 if __name__ == '__main__':

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,251 @@
+import datetime
+import json
+import unittest
+
+import mock
+import pytz
+import server.greenpithumb.greenpithumb.db_store as db_store
+
+from server import app
+from server import images
+
+
+class AppTest(unittest.TestCase):
+
+    def assertJsonEqual(self, expected, actual):
+        json.loads(expected)
+        json.loads(actual)
+        self.assertEqual(json.loads(expected), json.loads(actual))
+
+    def test_temperature_history_empty_db(self):
+        mock_temperature_store = mock.Mock(spec_set=db_store.TemperatureStore)
+        mock_temperature_store.get.return_value = []
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=mock_temperature_store,
+            light_store=None,
+            soil_moisture_store=None,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/temperatureHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("[]", response.data)
+
+    def test_temperature_history_non_empty_db(self):
+        mock_temperature_store = mock.Mock(spec_set=db_store.TemperatureStore)
+        mock_temperature_store.get.return_value = [
+            db_store.TemperatureRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 10, 51, 0, tzinfo=pytz.utc),
+                temperature=57.3),
+            db_store.TemperatureRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 11, 39, 0, tzinfo=pytz.utc),
+                temperature=68.2),
+        ]
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=mock_temperature_store,
+            light_store=None,
+            soil_moisture_store=None,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/temperatureHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("""
+            [
+                {
+                    "timestamp": "20170415T1051Z",
+                    "temperature": 57.3
+                },
+                {
+                    "timestamp": "20170415T1139Z",
+                    "temperature": 68.2
+                }
+            ]
+            """, response.data)
+
+    def test_light_history_empty_db(self):
+        mock_light_store = mock.Mock(spec_set=db_store.LightStore)
+        mock_light_store.get.return_value = []
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=None,
+            light_store=mock_light_store,
+            soil_moisture_store=None,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/lightHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("[]", response.data)
+
+    def test_light_history_non_empty_db(self):
+        mock_light_store = mock.Mock(spec_set=db_store.LightStore)
+        mock_light_store.get.return_value = [
+            db_store.LightRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 10, 51, 0, tzinfo=pytz.utc),
+                light=57.3),
+            db_store.LightRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 11, 39, 0, tzinfo=pytz.utc),
+                light=68.2),
+        ]
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=None,
+            light_store=mock_light_store,
+            soil_moisture_store=None,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/lightHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("""
+            [
+                {
+                    "timestamp": "20170415T1051Z",
+                    "light": 57.3
+                },
+                {
+                    "timestamp": "20170415T1139Z",
+                    "light": 68.2
+                }
+            ]
+            """, response.data)
+
+    def test_soil_moisture_history_empty_db(self):
+        mock_soil_moisture_store = mock.Mock(spec_set=db_store.SoilMoistureStore)
+        mock_soil_moisture_store.get.return_value = []
+
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=None,
+            light_store=None,
+            soil_moisture_store=mock_soil_moisture_store,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/soilMoistureHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("[]", response.data)
+
+    def test_soil_moisture_history_non_empty_db(self):
+        mock_soil_moisture_store = mock.Mock(spec_set=db_store.SoilMoistureStore)
+        mock_soil_moisture_store.get.return_value = [
+            db_store.SoilMoistureRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 10, 51, 0, tzinfo=pytz.utc),
+                soil_moisture=57.3),
+            db_store.SoilMoistureRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 11, 39, 0, tzinfo=pytz.utc),
+                soil_moisture=68.2),
+        ]
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=None,
+            light_store=None,
+            soil_moisture_store=mock_soil_moisture_store,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/soilMoistureHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("""
+            [
+                {
+                    "timestamp": "20170415T1051Z",
+                    "soil_moisture": 57.3
+                },
+                {
+                    "timestamp": "20170415T1139Z",
+                    "soil_moisture": 68.2
+                }
+            ]
+            """, response.data)
+
+    def test_humidity_history_empty_db(self):
+        mock_humidity_store = mock.Mock(spec_set=db_store.HumidityStore)
+        mock_humidity_store.get.return_value = []
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=None,
+            light_store=None,
+            soil_moisture_store=None,
+            humidity_store=mock_humidity_store).test_client(self)
+        response = app_client.get('/humidityHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("[]", response.data)
+
+    def test_humidity_history_non_empty_db(self):
+        mock_humidity_store = mock.Mock(spec_set=db_store.HumidityStore)
+        mock_humidity_store.get.return_value = [
+            db_store.HumidityRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 10, 51, 0, tzinfo=pytz.utc),
+                humidity=57.3),
+            db_store.HumidityRecord(
+                timestamp=datetime.datetime(
+                    2017, 4, 15, 11, 39, 0, tzinfo=pytz.utc),
+                humidity=68.2),
+        ]
+        app_client = app.create(
+            image_indexer=None,
+            temperature_store=None,
+            light_store=None,
+            soil_moisture_store=None,
+            humidity_store=mock_humidity_store).test_client(self)
+        response = app_client.get('/humidityHistory.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("""
+            [
+                {
+                    "timestamp": "20170415T1051Z",
+                    "humidity": 57.3
+                },
+                {
+                    "timestamp": "20170415T1139Z",
+                    "humidity": 68.2
+                }
+            ]
+            """, response.data)
+
+    def test_images_empty_index(self):
+        mock_image_indexer = mock.Mock(spec_set=images.Indexer)
+        mock_image_indexer.index.return_value = []
+        app_client = app.create(
+            image_indexer=mock_image_indexer,
+            temperature_store=None,
+            light_store=None,
+            soil_moisture_store=None,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/images.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("[]", response.data)
+
+    def test_images_non_empty_index(self):
+        mock_image_indexer = mock.Mock(spec_set=images.Indexer)
+        mock_image_indexer.index.return_value = [
+            {
+                'timestamp': datetime.datetime(
+                    2017, 4, 1, 18, 51, 0, tzinfo=pytz.utc),
+                'filename': '2017-04-01T1851Z.jpg',
+            },
+            {
+                'timestamp': datetime.datetime(
+                    2017, 4, 1, 18, 53, 0, tzinfo=pytz.utc),
+                'filename': '2017-04-01T1853Z.jpg',
+            },
+        ]
+        app_client = app.create(
+            image_indexer=mock_image_indexer,
+            temperature_store=None,
+            light_store=None,
+            soil_moisture_store=None,
+            humidity_store=None).test_client(self)
+        response = app_client.get('/images.json')
+        self.assertEqual(200, response.status_code)
+        self.assertJsonEqual("""
+            [
+              {
+                "timestamp": "20170401T1851Z",
+                "filename": "2017-04-01T1851Z.jpg"
+              },
+              {
+                "timestamp": "20170401T1853Z",
+                "filename": "2017-04-01T1853Z.jpg"
+              }
+            ]
+            """, response.data)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -110,7 +110,8 @@ class AppTest(unittest.TestCase):
             """, response.data)
 
     def test_soil_moisture_history_empty_db(self):
-        mock_soil_moisture_store = mock.Mock(spec_set=db_store.SoilMoistureStore)
+        mock_soil_moisture_store = mock.Mock(
+            spec_set=db_store.SoilMoistureStore)
         mock_soil_moisture_store.get.return_value = []
 
         app_client = app.create(
@@ -124,7 +125,8 @@ class AppTest(unittest.TestCase):
         self.assertJsonEqual("[]", response.data)
 
     def test_soil_moisture_history_non_empty_db(self):
-        mock_soil_moisture_store = mock.Mock(spec_set=db_store.SoilMoistureStore)
+        mock_soil_moisture_store = mock.Mock(
+            spec_set=db_store.SoilMoistureStore)
         mock_soil_moisture_store.get.return_value = [
             db_store.SoilMoistureRecord(
                 timestamp=datetime.datetime(


### PR DESCRIPTION
Switching from the klein web framework to Flask because Flask directly supports
unit testing, whereas klein does not.

Adding unit test coverage for the HTTP request serving logic.

Note: The unit tests use mock.Mock(spec_set=...) here because they're mocking out
dependencies in the GreenPiThumb backend and we've had bugs from the backend
library and the frontend library going out of sync. Setting an explicit mock
spec_set means that our tests will fail if we try to mock out a method that doesn't
really exist on the interface we're mocking.